### PR TITLE
The openhue.LoadConf() function now returns an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import (
 
 func main() {
 
-	home, _ := openhue.NewHome(openhue.LoadConf())
+	home, _ := openhue.NewHome(openhue.LoadConfNoError())
 	rooms, _ := home.GetRooms()
 
 	for id, room := range rooms {

--- a/helpers.go
+++ b/helpers.go
@@ -3,7 +3,6 @@ package openhue
 import (
 	"fmt"
 	"gopkg.in/yaml.v3"
-	"log"
 	"os"
 )
 
@@ -13,27 +12,39 @@ type Toggleable interface {
 	IsOn() bool
 }
 
+type Conf struct {
+	bridgeIP string
+	apiKey   string
+}
+
 // LoadConf looks up your Hue Bridge IP and Api Key from the well-known OpenHue standard configuration file.
-func LoadConf() (string, string) {
+func LoadConf() (*Conf, error) {
 
 	homedir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("unable to get home directory: %w", err)
 	}
 
 	yamlFile, err := os.ReadFile(homedir + "/.openhue/config.yaml")
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("unable to read ~/.openhue/config.yaml: %w", err)
 	}
 
 	c := make(map[string]interface{})
 
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("unable to parse ~/.openhue/config.yaml: %w", err)
 	}
 
-	return c["bridge"].(string), c["key"].(string)
+	return &Conf{c["bridge"].(string), c["key"].(string)}, nil
+}
+
+// LoadConfNoError is similar to LoadConf() except that it will fatal if there are any errors.
+func LoadConfNoError() (string, string) {
+	conf, err := LoadConf()
+	CheckErr(err)
+	return conf.bridgeIP, conf.apiKey
 }
 
 // CheckErr prints the msg with the prefix 'Error:' and exits with error code 1. If the msg is a nil, it does nothing.

--- a/playground/toggle_lights/main.go
+++ b/playground/toggle_lights/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 
-	home, err := openhue.NewHome(openhue.LoadConf())
+	home, err := openhue.NewHome(openhue.LoadConfNoError())
 	openhue.CheckErr(err)
 
 	lights, err := home.GetLights()

--- a/playground/toggle_rooms/main.go
+++ b/playground/toggle_rooms/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	home, err := openhue.NewHome(openhue.LoadConf())
+	home, err := openhue.NewHome(openhue.LoadConfNoError())
 	openhue.CheckErr(err)
 
 	rooms, err := home.GetRooms()


### PR DESCRIPTION
:warning: **BREAKING CHANGE**

Modified the values returned by the `openhue.LoadConf()` function so the user can know why it failed to read from the well-known configuration file.

A `openhue.LoadConfNoError()` is still available as it is pretty useful in playground applications. 