### PR TITLE
docs: improve README with better structure and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,140 @@
+<div align="center">
+
 # OpenHue Go
-![OpenHue Go Logo Medium Size](./docs/logo-md.png)
+
+![OpenHue Go Logo](./docs/logo-md.png)
+
+**A modern Go library for Philips Hue smart lighting systems**
 
 [![Build](https://github.com/openhue/openhue-go/actions/workflows/build.yml/badge.svg)](https://github.com/openhue/openhue-go/actions/workflows/build.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/openhue/openhue-go)](https://goreportcard.com/report/github.com/openhue/openhue-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/openhue/openhue-go.svg)](https://pkg.go.dev/github.com/openhue/openhue-go)
+[![GitHub License](https://img.shields.io/github/license/openhue/openhue-go)](https://github.com/openhue/openhue-go/blob/main/LICENSE)
 
-## Overview
-OpenHue Go is a library written in Goland for interacting with the Philips Hue smart lighting systems.
-This project is based on the [OpenHue API](https://github.com/openhue/openhue-api) specification. 
-Therefore, most of its code is automatically generated thanks to the [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) project.
+[Features](#features) • [Installation](#installation) • [Quick Start](#quick-start) • [Documentation](#documentation) • [Contributing](#contributing)
 
-## Usage
-Use the following command to import the library: 
+</div>
+
+---
+
+## Features
+
+🏠 **Home Abstraction** — Intuitive entry point to interact with your entire Hue ecosystem  
+🔍 **Bridge Discovery** — Automatic bridge detection via mDNS with URL fallback  
+🔐 **Easy Authentication** — Simplified link button authentication flow  
+💡 **Full API Coverage** — Auto-generated from the [OpenHue API](https://github.com/openhue/openhue-api) specification  
+⚡ **Type-Safe** — Strongly typed Go structs for all Hue resources  
+
+## Installation
+
+**Requirements:** Go 1.23+
+
 ```shell
 go get -u github.com/openhue/openhue-go
 ```
-And check the following example that toggles all the rooms of your house:
+
+## Quick Start
+
+Toggle all rooms in your home with just a few lines of code:
+
 ```go
 package main
 
 import (
-	"fmt"
-	"github.com/openhue/openhue-go"
-	"log"
+    "fmt"
+    "github.com/openhue/openhue-go"
 )
 
 func main() {
+    home, _ := openhue.NewHome(openhue.LoadConfNoError())
+    rooms, _ := home.GetRooms()
 
-	home, _ := openhue.NewHome(openhue.LoadConfNoError())
-	rooms, _ := home.GetRooms()
+    for id, room := range rooms {
+        fmt.Printf("> Toggling room %s (%s)\n", *room.Metadata.Name, id)
 
-	for id, room := range rooms {
-
-		fmt.Printf("> Toggling room %s (%s)\n", *room.Metadata.Name, id)
-
-		for serviceId, serviceType := range room.GetServices() {
-
-			if serviceType == openhue.ResourceIdentifierRtypeGroupedLight {
-				groupedLight, _ := home.GetGroupedLightById(serviceId)
-
-				home.UpdateGroupedLight(*groupedLight.Id, openhue.GroupedLightPut{
-					On: groupedLight.Toggle(),
-				})
-			}
-		}
-	}
+        for serviceId, serviceType := range room.GetServices() {
+            if serviceType == openhue.ResourceIdentifierRtypeGroupedLight {
+                groupedLight, _ := home.GetGroupedLightById(serviceId)
+                home.UpdateGroupedLight(*groupedLight.Id, openhue.GroupedLightPut{
+                    On: groupedLight.Toggle(),
+                })
+            }
+        }
+    }
 }
 ```
+
 > [!NOTE]  
-> The `openhue.LoadConf()` function allows loading the configuration from the well-known configuration file.
-> Please refer to [this guide](https://www.openhue.io/cli/setup#manual-configuration) for more information.
+> The `openhue.LoadConf()` function loads configuration from the well-known configuration file.  
+> See the [configuration guide](https://www.openhue.io/cli/setup#manual-configuration) for details.
+
+## Documentation
 
 ### Bridge Discovery
-Bridge Discovery on the local network has been made easy through the `BridgeDiscovery` helper: 
+
+Automatically discover Hue bridges on your local network:
+
 ```go
-package main
+bridge, err := openhue.NewBridgeDiscovery(openhue.WithTimeout(1 * time.Second)).Discover()
+openhue.CheckErr(err)
 
-import (
-	"fmt"
-	"github.com/openhue/openhue-go"
-	"log"
-	"time"
-)
-
-func main() {
-
-	bridge, err := openhue.NewBridgeDiscovery(openhue.WithTimeout(1 * time.Second)).Discover()
-	openhue.CheckErr(err)
-
-	fmt.Println(bridge) // Output: Bridge{instance: "Hue Bridge - 1A3E4F", host: "ecb5fa1a3e4f.local.", ip: "192.168.1.xx"}
-}
+fmt.Println(bridge)
+// Output: Bridge{instance: "Hue Bridge - 1A3E4F", host: "ecb5fa1a3e4f.local.", ip: "192.168.1.xx"}
 ```
-The `BridgeDiscovery.Discover()` function will first try to discover your local bridge via mDNS, 
-and if that fails then it tries using [discovery.meethue.com](https://discovery.meethue.com) URL.
 
-Options:
-- `openhue.WithTimeout` allows setting the mDNS discovery timeout. Default value is `5` seconds.
-- `openhue.WithDisabledUrlDiscovery` allows disabling the URL discovery.
+The discovery process tries mDNS first, then falls back to [discovery.meethue.com](https://discovery.meethue.com).
+
+**Options:**
+- `openhue.WithTimeout(duration)` — Set mDNS discovery timeout (default: 5 seconds)
+- `openhue.WithDisabledUrlDiscovery` — Disable URL fallback discovery
 
 ### Authentication
-Bridge authentication has been make simple via the `Authenticator` interface:
+
+Authenticate with your bridge using the link button:
+
 ```go
-package main
+bridge, _ := openhue.NewBridgeDiscovery(openhue.WithTimeout(1 * time.Second)).Discover()
+authenticator, _ := openhue.NewAuthenticator(bridge.IpAddress)
 
-import (
-	"fmt"
-	"github.com/openhue/openhue-go"
-	"time"
-)
+fmt.Println("Press the link button")
 
-func main() {
+var key string
+for len(key) == 0 {
+    apiKey, retry, err := authenticator.Authenticate()
 
-	bridge, err := openhue.NewBridgeDiscovery(openhue.WithTimeout(1 * time.Second)).Discover()
-	openhue.CheckErr(err)
-
-	authenticator, err := openhue.NewAuthenticator(bridge.IpAddress)
-	openhue.CheckErr(err)
-
-	fmt.Println("Press the link button")
-
-	var key string
-	for len(key) == 0 {
-
-		// try to authenticate
-		apiKey, retry, err := authenticator.Authenticate()
-
-		if err != nil && retry {
-			// link button not pressed
-			fmt.Printf(".")
-			time.Sleep(500 * time.Millisecond)
-		} else if err != nil && !retry {
-			// there is a real error
-			openhue.CheckErr(err)
-		} else {
-			key = apiKey
-		}
-	}
-
-	fmt.Println("\n", key)
+    if err != nil && retry {
+        fmt.Printf(".")
+        time.Sleep(500 * time.Millisecond)
+    } else if err != nil && !retry {
+        openhue.CheckErr(err)
+    } else {
+        key = apiKey
+    }
 }
-```
-In this example, we wait until the link button is pressed on the bridge. 
-The `Authenticator.Authenticate()` function returns three values:
-- `apiKey string` that is not empty when `retry = false` and `err == nil`
-- `retry bool` which indicates that the link button has not been pressed
-- `err error` which contains the error details
 
-**You can consider the authentication has failed whenever the `retry` value is `false` and the `err` is not `nil`.**
+fmt.Println("\n", key)
+```
+
+The `Authenticate()` function returns:
+- `apiKey` — The API key (non-empty on success)
+- `retry` — `true` if the link button hasn't been pressed yet
+- `err` — Error details if authentication failed
+
+> [!TIP]
+> Authentication has failed when `retry == false` and `err != nil`.
+
+## Related Projects
+
+- [OpenHue API](https://github.com/openhue/openhue-api) — OpenAPI specification for Philips Hue
+- [OpenHue CLI](https://github.com/openhue/openhue-cli) — Command-line interface built with this library
+- [openhue.io](https://www.openhue.io/) — Official documentation and guides
+
+## Contributing
+
+Contributions are welcome! Feel free to open issues and pull requests.
+
+This project uses [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) for code generation. Most code in `openhue.gen.go` is auto-generated — see the project structure before making changes.
 
 ## License
-[![GitHub License](https://img.shields.io/github/license/openhue/openhue-cli)](https://github.com/openhue/openhue-cli/blob/main/LICENSE)
 
-OpenHue is distributed under the [Apache License 2.0](http://www.apache.org/licenses/),
-making it open and free for anyone to use and contribute to.
-See the [license](./LICENSE) file for detailed terms.
+OpenHue Go is distributed under the [Apache License 2.0](http://www.apache.org/licenses/), making it open and free for anyone to use and contribute to. See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
## Summary

This PR modernizes the README to make it more visually appealing and easier to navigate.

## Changes

### Fixes
- **License badge** was pointing to `openhue-cli` instead of `openhue-go`
- **Typo**: "Goland" → "Go" (Goland is the IDE, not the language)

### Additions
- ✨ Centered header with tagline and quick navigation links
- 📋 **Features** section highlighting key capabilities with emojis
- 📦 Go version requirement (1.23+)
- 🔗 **Related Projects** section linking to ecosystem projects
- 🤝 **Contributing** section with guidance about code generation
- 💡 **TIP** callout for authentication failure detection

### Improvements
- Reorganized content under a **Documentation** section
- Streamlined code examples (removed redundant imports)
- Consistent use of GitHub callouts (NOTE, TIP)
- Better visual hierarchy and readability