### PR TITLE
feat: complete error response handling with rich API error details

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,31 +1,116 @@
 package openhue
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
+// ApiError represents an error returned by the Philips Hue API.
+// It includes the HTTP status code and any error details from the response body.
 type ApiError struct {
-	error
-	StatusCode int
+	StatusCode  int
+	Status      string
+	Description string
 }
 
 func (a *ApiError) Error() string {
-
-	if a.StatusCode == http.StatusForbidden {
-		return "openhue api error: wrong API key"
+	if a.Description != "" {
+		return fmt.Sprintf("openhue api error (%d): %s", a.StatusCode, a.Description)
 	}
 
-	return fmt.Sprintf("openhue api error: %d", a.StatusCode)
+	// Fallback messages for common status codes
+	switch a.StatusCode {
+	case http.StatusUnauthorized:
+		return "openhue api error (401): unauthorized - invalid or missing API key"
+	case http.StatusForbidden:
+		return "openhue api error (403): forbidden - wrong API key"
+	case http.StatusNotFound:
+		return "openhue api error (404): resource not found"
+	case http.StatusConflict:
+		return "openhue api error (409): conflict"
+	case http.StatusTooManyRequests:
+		return "openhue api error (429): too many requests - rate limited"
+	case http.StatusInternalServerError:
+		return "openhue api error (500): internal server error"
+	case http.StatusServiceUnavailable:
+		return "openhue api error (503): service unavailable"
+	default:
+		return fmt.Sprintf("openhue api error (%d): %s", a.StatusCode, a.Status)
+	}
 }
 
+// Sentinel errors for common API error conditions.
+// Use errors.Is() to check for these specific error types.
+var (
+	ErrUnauthorized        = errors.New("unauthorized")
+	ErrForbidden           = errors.New("forbidden")
+	ErrNotFound            = errors.New("not found")
+	ErrConflict            = errors.New("conflict")
+	ErrTooManyRequests     = errors.New("too many requests")
+	ErrInternalServerError = errors.New("internal server error")
+	ErrServiceUnavailable  = errors.New("service unavailable")
+)
+
+// Is implements errors.Is for ApiError, allowing checks like:
+//
+//	if errors.Is(err, openhue.ErrNotFound) { ... }
+func (a *ApiError) Is(target error) bool {
+	switch a.StatusCode {
+	case http.StatusUnauthorized:
+		return errors.Is(target, ErrUnauthorized)
+	case http.StatusForbidden:
+		return errors.Is(target, ErrForbidden)
+	case http.StatusNotFound:
+		return errors.Is(target, ErrNotFound)
+	case http.StatusConflict:
+		return errors.Is(target, ErrConflict)
+	case http.StatusTooManyRequests:
+		return errors.Is(target, ErrTooManyRequests)
+	case http.StatusInternalServerError:
+		return errors.Is(target, ErrInternalServerError)
+	case http.StatusServiceUnavailable:
+		return errors.Is(target, ErrServiceUnavailable)
+	default:
+		return false
+	}
+}
+
+// apiResponse is the interface that all generated response types implement.
 type apiResponse interface {
 	Status() string
 	StatusCode() int
 }
 
+// newApiError creates an ApiError from an API response, extracting error details if available.
 func newApiError(resp apiResponse) error {
-	return &ApiError{
-		StatusCode: resp.StatusCode(),
+	statusCode := resp.StatusCode()
+	apiErr := &ApiError{
+		StatusCode: statusCode,
+		Status:     resp.Status(),
 	}
+
+	// Try to extract error description from the response using reflection
+	if errResp := extractErrorFromResponse(resp, statusCode); errResp != nil && errResp.Errors != nil {
+		apiErr.Description = extractErrorDescriptions(*errResp.Errors)
+	}
+
+	return apiErr
+}
+
+// extractErrorDescriptions joins all error descriptions into a single string.
+func extractErrorDescriptions(errs []Error) string {
+	if len(errs) == 0 {
+		return ""
+	}
+
+	var descriptions []string
+	for _, e := range errs {
+		if e.Description != nil && *e.Description != "" {
+			descriptions = append(descriptions, *e.Description)
+		}
+	}
+
+	return strings.Join(descriptions, "; ")
 }

--- a/openhue_test.go
+++ b/openhue_test.go
@@ -2,14 +2,15 @@ package openhue
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	"errors"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestNewHome(t *testing.T) {
-
+func TestGetDevices_Forbidden(t *testing.T) {
 	home, m := NewTestHome()
 
 	resp := GetDevicesResponse{
@@ -19,5 +20,129 @@ func TestNewHome(t *testing.T) {
 
 	_, err := home.GetDevices(context.Background())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "openhue api error: wrong API key")
+	assert.ErrorContains(t, err, "openhue api error (403)")
+	assert.ErrorContains(t, err, "forbidden")
+	assert.True(t, errors.Is(err, ErrForbidden))
+}
+
+func TestGetDevices_NotFound(t *testing.T) {
+	home, m := NewTestHome()
+
+	resp := GetDevicesResponse{
+		HTTPResponse: &http.Response{StatusCode: 404},
+	}
+	m.On("GetDevicesWithResponse", mock.Anything, mock.Anything).Return(&resp, nil)
+
+	_, err := home.GetDevices(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestGetDevices_WithErrorDescription(t *testing.T) {
+	home, m := NewTestHome()
+
+	description := "resource not found: device xyz"
+	resp := GetDevicesResponse{
+		HTTPResponse: &http.Response{StatusCode: 404},
+		JSON404: &NotFound{
+			Errors: &[]Error{
+				{Description: &description},
+			},
+		},
+	}
+	m.On("GetDevicesWithResponse", mock.Anything, mock.Anything).Return(&resp, nil)
+
+	_, err := home.GetDevices(context.Background())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "resource not found: device xyz")
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestGetDevices_Unauthorized(t *testing.T) {
+	home, m := NewTestHome()
+
+	resp := GetDevicesResponse{
+		HTTPResponse: &http.Response{StatusCode: 401},
+	}
+	m.On("GetDevicesWithResponse", mock.Anything, mock.Anything).Return(&resp, nil)
+
+	_, err := home.GetDevices(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized))
+}
+
+func TestGetDevices_TooManyRequests(t *testing.T) {
+	home, m := NewTestHome()
+
+	resp := GetDevicesResponse{
+		HTTPResponse: &http.Response{StatusCode: 429},
+	}
+	m.On("GetDevicesWithResponse", mock.Anything, mock.Anything).Return(&resp, nil)
+
+	_, err := home.GetDevices(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTooManyRequests))
+	assert.ErrorContains(t, err, "rate limited")
+}
+
+func TestApiError_Is(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		target     error
+		want       bool
+	}{
+		{"401 is ErrUnauthorized", 401, ErrUnauthorized, true},
+		{"403 is ErrForbidden", 403, ErrForbidden, true},
+		{"404 is ErrNotFound", 404, ErrNotFound, true},
+		{"409 is ErrConflict", 409, ErrConflict, true},
+		{"429 is ErrTooManyRequests", 429, ErrTooManyRequests, true},
+		{"500 is ErrInternalServerError", 500, ErrInternalServerError, true},
+		{"503 is ErrServiceUnavailable", 503, ErrServiceUnavailable, true},
+		{"403 is not ErrNotFound", 403, ErrNotFound, false},
+		{"200 is not any sentinel", 200, ErrNotFound, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &ApiError{StatusCode: tt.statusCode}
+			got := errors.Is(err, tt.target)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApiError_ErrorMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiErr      *ApiError
+		wantContain string
+	}{
+		{
+			"with description",
+			&ApiError{StatusCode: 404, Description: "light not found"},
+			"light not found",
+		},
+		{
+			"forbidden without description",
+			&ApiError{StatusCode: 403},
+			"wrong API key",
+		},
+		{
+			"not found without description",
+			&ApiError{StatusCode: 404},
+			"resource not found",
+		},
+		{
+			"unknown status code",
+			&ApiError{StatusCode: 418, Status: "I'm a teapot"},
+			"I'm a teapot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.apiErr.Error(), tt.wantContain)
+		})
+	}
 }

--- a/response_helpers.go
+++ b/response_helpers.go
@@ -1,0 +1,80 @@
+package openhue
+
+import (
+	"net/http"
+	"reflect"
+)
+
+// extractErrorFromResponse attempts to extract error details from any response type.
+// It uses reflection to check for common error fields (JSON4xx, JSON5xx) present
+// in the generated response structs.
+func extractErrorFromResponse(resp any, statusCode int) *ErrorResponse {
+	v := reflect.ValueOf(resp)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	// Map status codes to field names
+	fieldName := statusCodeToFieldName(statusCode)
+	if fieldName == "" {
+		return nil
+	}
+
+	field := v.FieldByName(fieldName)
+	if !field.IsValid() || field.IsNil() {
+		return nil
+	}
+
+	// All error response types (Forbidden, NotFound, etc.) are type aliases for ErrorResponse.
+	// We can safely convert via the underlying pointer type.
+	if field.CanInterface() {
+		// Use reflection to get the underlying value since all types are aliases
+		if field.Type().Kind() == reflect.Ptr && field.Type().Elem().Name() == "ErrorResponse" {
+			if errResp, ok := field.Interface().(*ErrorResponse); ok {
+				return errResp
+			}
+		}
+
+		// For type aliases, convert the underlying pointer
+		if field.Elem().CanAddr() {
+			ptr := field.Elem().Addr()
+			if errResp, ok := ptr.Interface().(*ErrorResponse); ok {
+				return errResp
+			}
+		}
+	}
+
+	return nil
+}
+
+// statusCodeToFieldName maps HTTP status codes to the corresponding field name
+// in generated response structs.
+func statusCodeToFieldName(statusCode int) string {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return "JSON401"
+	case http.StatusForbidden:
+		return "JSON403"
+	case http.StatusNotFound:
+		return "JSON404"
+	case http.StatusMethodNotAllowed:
+		return "JSON405"
+	case http.StatusNotAcceptable:
+		return "JSON406"
+	case http.StatusConflict:
+		return "JSON409"
+	case http.StatusTooManyRequests:
+		return "JSON429"
+	case http.StatusInternalServerError:
+		return "JSON500"
+	case http.StatusServiceUnavailable:
+		return "JSON503"
+	case http.StatusInsufficientStorage:
+		return "JSON507"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary

This PR completes the error response handling that was previously marked as partially fixed. The API now extracts and exposes detailed error information from the Philips Hue API responses.

## Changes

### New Features
- **Rich error descriptions**: Extracts error details from API response body (`JSON4xx`/`JSON5xx` fields)
- **Sentinel errors**: Added `ErrNotFound`, `ErrForbidden`, `ErrUnauthorized`, `ErrConflict`, `ErrTooManyRequests`, `ErrInternalServerError`, `ErrServiceUnavailable`
- **errors.Is() support**: Easily check error types with `errors.Is(err, openhue.ErrNotFound)`
- **Improved error messages**: Status-specific fallback messages when no description is available

### Files Changed
- `error.go` - Enhanced `ApiError` struct with `Status` and `Description` fields, added sentinel errors and `Is()` method
- `response_helpers.go` - New file with reflection-based extraction of error responses from generated types
- `openhue_test.go` - Comprehensive tests for all error scenarios

## Usage

```go
lights, err := home.GetLights(ctx)
if err != nil {
    if errors.Is(err, openhue.ErrNotFound) {
        // Handle not found
    } else if errors.Is(err, openhue.ErrForbidden) {
        // Handle wrong API key
    } else if errors.Is(err, openhue.ErrTooManyRequests) {
        // Handle rate limiting
    }
}
```

## Breaking Change

The `ApiError` struct has been updated:
- Added `Status` and `Description` fields
- Error message format changed from `openhue api error: wrong API key` to `openhue api error (403): forbidden - wrong API key`