### PR TITLE
feat: add functional options pattern for Home

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -23,7 +23,7 @@ type authenticatorImpl struct {
 type authOpt func(b *authenticatorImpl)
 
 func NewAuthenticator(bridgeIP string, opts ...authOpt) (Authenticator, error) {
-	client, err := newClient(bridgeIP, "")
+	client, err := newClient(bridgeIP, "", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
This PR implements the functional options pattern for the Home struct, allowing users to customize HTTP client settings when creating a new Home instance.

## Changes
- Add `HomeOption` type for configuring Home instances
- Add `WithCustomHTTPClient` option for providing a custom HTTP client
- Add `WithRequestTimeout` option for setting request timeout (default: 30s)
- Update `NewHome` signature to accept variadic `HomeOption` arguments
- Update `newClient` to support nil config for backward compatibility (used by auth.go)
- Add comprehensive tests for functional options

## Usage Examples
```go
// Basic usage (unchanged)
home, err := openhue.NewHome("192.168.1.2", "api-key")

// With custom timeout
home, err := openhue.NewHome("192.168.1.2", "api-key", openhue.WithRequestTimeout(30*time.Second))

// With custom HTTP client
customClient := &http.Client{Timeout: 60 * time.Second}
home, err := openhue.NewHome("192.168.1.2", "api-key", openhue.WithCustomHTTPClient(customClient))
```

## Breaking Changes
None - the existing `NewHome(bridgeIP, apiKey string)` signature remains compatible.

## References
- Addresses item #1 in Code Quality Improvements section of CODE_REVIEW.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home instance creation now supports functional options for flexible configuration, allowing users to provide custom HTTP clients and specify request timeouts to meet their specific networking requirements.

* **Tests**
  * Added comprehensive test coverage for the new functional options, including validation of custom HTTP clients and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->